### PR TITLE
fix: add missing log field to influx site config

### DIFF
--- a/site/config.json
+++ b/site/config.json
@@ -30,6 +30,9 @@
 		"host": "es:9200"
 	},
 	"influx": {
-		"host": "influx"
+		"host": "influx",
+		"site": {
+			"log": "influx"
+		}
 	}
 }


### PR DESCRIPTION
Running the current `site-dev` service results in a server error because an attribute of an undefined `config.json` field is being accessed.